### PR TITLE
Add ActiveSupport::Notifications instrumentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About
+
+Resteze is a Ruby gem that provides a framework for building REST API client libraries. Consumers `include Resteze` in their own module and get a fully namespaced set of classes (Client, ApiResource, ListObject, Error hierarchy, etc.) that they extend to define resources.
+
+## Commands
+
+```bash
+bundle exec rake          # Run tests + RuboCop (default task)
+bundle exec rake test     # Run tests only
+bundle exec rake rubocop  # Lint only
+bundle exec ruby -Ilib:test test/resteze/client_test.rb  # Run a single test file
+bundle exec guard         # Watch mode: re-runs tests on file changes
+COVERAGE=1 bundle exec rake test  # Run tests with coverage report
+```
+
+## Architecture
+
+### The `include Resteze` pattern
+
+When a module does `include Resteze`, the `included` block in `lib/resteze.rb` fires and sets up a full set of namespaced constants inside the consuming module:
+
+- `MyApi::Object` — base Hashie::Trash subclass for all resource objects
+- `MyApi::Client` — Faraday-based HTTP client (thread-safe via `Thread.current`)
+- `MyApi::ApiResource` — extends Object with `retrieve`, `resource_path`, `refresh`
+- `MyApi::ListObject` — Hashie::Array subclass for paginated list responses
+- `MyApi::Middleware::RaiseError` — Faraday middleware for HTTP error handling
+- `MyApi::List`, `MyApi::Save` — mixins consumers include on specific resources
+- `MyApi::Error` and all subclasses — namespaced error hierarchy
+
+This means each consuming gem gets its own isolated class hierarchy; errors from one API won't be caught by rescue clauses for another.
+
+### `ApiModule` — the ancestry resolver
+
+`Resteze::ApiModule` is mixed into every class in the hierarchy. Its `api_module` class method walks the constant name ancestry (`Widget` → `MyApi::Widget` → `MyApi`) to find the module that `include`d Resteze. This is what allows `MyApi::Widget.request(...)` to automatically use `MyApi::Client` rather than needing any explicit wiring.
+
+### Request flow
+
+```
+MyApi::Widget.retrieve(id)
+  → ApiResource#refresh
+  → Request.request(:get, path)
+  → MyApi::Client.active_client.execute_request(method, path)
+  → Faraday connection (thread-local default_client)
+  → Middleware::RaiseError
+  → Response.from_faraday_response
+  → Object#initialize_from(resp.data)
+```
+
+GET/HEAD/DELETE params become query strings; all other methods send a JSON body.
+
+### Object / property system
+
+`Resteze::Object` extends `Hashie::Trash`, which provides typed `property` declarations with optional transforms, defaults, and translations (key remapping). Unknown keys that don't match a declared property are stored in `@property_bag` rather than raising, allowing forward compatibility with API changes.
+
+`object_key` (default: `nil`) lets a resource unwrap a top-level envelope key from API responses. `list_key` (default: `:data`) tells `ListObject` which key holds the array of items.
+
+### Mixins: List and Save
+
+- **`Resteze::List`** adds a class-level `.list(params:)` that issues a GET to `resource_path` and constructs a `ListObject`.
+- **`Resteze::Save`** adds `#save` which issues POST (new) or PUT (persisted) based on `persisted?` (presence of `id`).
+
+Both are opt-in; include them on a resource class when needed.
+
+### Testing helpers
+
+`lib/resteze/testing/` provides helpers for consumers testing their own gem:
+- `Resteze::Testing::Minitest` — `has_property` assertion helper and `assert_config_property`
+- `Resteze::Testing::RSpec` — equivalent helpers for RSpec
+
+The gem's own tests use **Minitest** with **WebMock** (net connections disabled globally). The test helper defines `AcmeApi` as a reference implementation of a consuming module.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,37 @@ end
 
 You can define additional resources, customize paths, and add methods as needed. Resteze handles requests, responses, and error management for you, so you can focus on your API's business logic.
 
+### Instrumentation
+
+Resteze fires an `ActiveSupport::Notifications` event for every HTTP request, making it easy to track performance metrics in host applications.
+
+The event name is `request.<api_module_key>`, where the key is derived from your module name (e.g. `MyCoolApi` → `"request.my_cool_api"`).
+
+```ruby
+ActiveSupport::Notifications.subscribe("request.my_cool_api") do |event|
+  event.duration            # elapsed time in milliseconds
+  event.payload[:method]    # :get, :post, :put, etc.
+  event.payload[:path]      # "/widgets/123"
+  event.payload[:status]    # 200, 404, etc.
+  event.payload[:request_id] # value of the Request-Id response header
+  event.payload[:api_module] # "MyCoolApi"
+  event.payload[:exception]  # [ExceptionClass, message] if the request raised
+end
+```
+
+The event fires on every request — including those that raise errors — so you can feed `event.duration` directly into a histogram for p95 and other percentile calculations. Because `ActiveSupport::Notifications` short-circuits when there are no subscribers, there is no overhead when instrumentation is not in use.
+
+To override the event name key for a module:
+
+```ruby
+module MyCoolApi
+  include Resteze
+
+  INSTRUMENTATION_KEY = "cool_api"
+end
+# => subscribes to "request.cool_api"
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/rwx-services/resteze.

--- a/lib/resteze.rb
+++ b/lib/resteze.rb
@@ -18,6 +18,7 @@ require "resteze/save"
 require "resteze/object"
 
 # API Classes
+require "resteze/instrumentation"
 require "resteze/client"
 require "resteze/errors"
 require "resteze/list_object"
@@ -79,6 +80,7 @@ module Resteze
     end
 
     # Setup magic constants
+    const_set :INSTRUMENTATION_KEY, name.underscore.tr("/", "_") unless const_defined?("#{self}::INSTRUMENTATION_KEY")
     const_set :Object,      Class.new(Resteze::Object)
     const_set :Client,      Class.new(Resteze::Client)
     const_set :Response,    Class.new(Resteze::Response)

--- a/lib/resteze/client.rb
+++ b/lib/resteze/client.rb
@@ -1,6 +1,7 @@
 module Resteze
   class Client
     include Resteze::ApiModule
+    prepend Resteze::Instrumentation
 
     def self.user_agent
       [

--- a/lib/resteze/instrumentation.rb
+++ b/lib/resteze/instrumentation.rb
@@ -1,0 +1,14 @@
+module Resteze
+  module Instrumentation
+    def execute_request(method, path, ...)
+      payload = { method: method, path: path, api_module: api_module.name }
+
+      ActiveSupport::Notifications.instrument("request.#{api_module::INSTRUMENTATION_KEY}", payload) do
+        super.tap do |response|
+          payload[:status]     = response.http_status
+          payload[:request_id] = response.request_id
+        end
+      end
+    end
+  end
+end

--- a/lib/resteze/version.rb
+++ b/lib/resteze/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resteze
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/test/resteze/instrumentation_test.rb
+++ b/test/resteze/instrumentation_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+module Resteze
+  class InstrumentationTest < Minitest::Spec
+    subject { AcmeApi::Client.new }
+
+    before do
+      stub_request(:get, api_url("/widgets/1"))
+        .to_return(body: JSON.generate({ id: "1", foo: "bar" }), status: 200,
+                   headers: { "Request-Id" => "req_abc123" })
+    end
+
+    def capture_events(event_name)
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe(event_name) do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+      yield
+      events
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    describe "INSTRUMENTATION_KEY" do
+      it "is derived from the api_module name" do
+        assert_equal "acme_api", AcmeApi::INSTRUMENTATION_KEY
+      end
+    end
+
+    describe "#execute_request instrumentation" do
+      it "fires an event named after the api_module" do
+        events = capture_events("request.acme_api") do
+          subject.execute_request(:get, "/widgets/1")
+        end
+
+        assert_equal 1, events.size
+      end
+
+      it "populates the payload with request and response details" do
+        events = capture_events("request.acme_api") do
+          subject.execute_request(:get, "/widgets/1")
+        end
+
+        event = events.first
+
+        assert_equal :get,         event.payload[:method]
+        assert_equal "/widgets/1", event.payload[:path]
+        assert_equal 200,          event.payload[:status]
+        assert_equal "req_abc123", event.payload[:request_id]
+        assert_equal "AcmeApi",    event.payload[:api_module]
+      end
+
+      it "records a non-zero duration" do
+        events = capture_events("request.acme_api") do
+          subject.execute_request(:get, "/widgets/1")
+        end
+
+        assert_operator events.first.duration, :>, 0
+      end
+
+      it "fires the event and captures the exception on error" do
+        stub_request(:get, api_url("/widgets/missing")).to_return(status: 404)
+
+        events = capture_events("request.acme_api") do
+          assert_raises(AcmeApi::ResourceNotFound) do
+            subject.execute_request(:get, "/widgets/missing")
+          end
+        end
+
+        assert_equal 1, events.size
+        refute_nil events.first.payload[:exception]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fires a `request.<api_module_key>` event on every HTTP request via `ActiveSupport::Notifications`
- Event payload includes `method`, `path`, `status`, `request_id`, `api_module`, and `exception` (on error)
- Duration tracked automatically by AS::N — feed `event.duration` directly into a p95 histogram
- Implemented via `prepend Resteze::Instrumentation` on `Client`, keeping `execute_request` untouched
- `INSTRUMENTATION_KEY` is derived from the consuming module name (e.g. `MyCoolApi` → `"my_cool_api"`) using the same `const_set` pattern as error classes; can be overridden per module

## Test plan

- [ ] `bundle exec rake` — all 177 tests pass, no RuboCop offenses
- [ ] Verify `request.acme_api` events fire with correct payload fields
- [ ] Verify events fire with exception info on 4xx/5xx responses
- [ ] Verify `INSTRUMENTATION_KEY` derivation for `AcmeApi` → `"acme_api"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)