### PR TITLE
Upgrade actions/checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - "3.4.4"
     name: Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -55,7 +55,7 @@ jobs:
           - "3.4.4"
     name: Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` from v4 to v7 in both CI jobs
- Resolves the Node.js 20 deprecation warning ("being forced to run on Node.js 24")

## What's new in v7
- Targets Node.js 24 natively
- Safer fork PR handling (refuses to check out fork code on `pull_request_target`/`workflow_run` by default)
- Security fixes for known vulnerabilities in dependencies

No behavior changes for this repo — workflows only use `push` and `pull_request` triggers, which are unaffected by the new fork PR restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)